### PR TITLE
Always use passphrase callback

### DIFF
--- a/src/openssl_ext/pkey/rsa.cr
+++ b/src/openssl_ext/pkey/rsa.cr
@@ -17,8 +17,10 @@ module OpenSSL::PKey
 
       priv = true
 
+      cb, cb_u = OpenSSL::PKey.passphrase_callback(passphrase)
+
       bio = GETS_BIO.new(io)
-      rsa_key = LibCrypto.pem_read_bio_rsa_private_key(bio, nil, nil, passphrase)
+      rsa_key = LibCrypto.pem_read_bio_rsa_private_key(bio, nil, cb, cb_u)
       io.rewind
 
       if rsa_key.null?
@@ -34,14 +36,14 @@ module OpenSSL::PKey
 
       if rsa_key.null?
         bio = GETS_BIO.new(io)
-        rsa_key = LibCrypto.pem_read_bio_rsa_public_key(bio, nil, nil, passphrase)
+        rsa_key = LibCrypto.pem_read_bio_rsa_public_key(bio, nil, cb, cb_u)
         priv = false unless rsa_key.null?
         io.rewind
       end
 
       if rsa_key.null?
         bio = GETS_BIO.new(io)
-        rsa_key = LibCrypto.pem_read_bio_rsa_pubkey(bio, nil, nil, passphrase)
+        rsa_key = LibCrypto.pem_read_bio_rsa_pubkey(bio, nil, cb, cb_u)
         priv = false unless rsa_key.null?
         io.rewind
       end


### PR DESCRIPTION
When the passphrase is passed by slice, the memory after the slice may not contain a null byte. Since openssl expects a null-terminated string, not a length-delimited string, the memory after the slice can be allocated by the GC and `strlen(passphrase)` fails.