### PR TITLE
Adding support for Openssl 3

### DIFF
--- a/src/openssl_ext/lib_crypto.cr
+++ b/src/openssl_ext/lib_crypto.cr
@@ -264,10 +264,21 @@ lib LibCrypto
   fun bio_ctrl = BIO_ctrl(bio : Bio*, cmd : LibC::Int, larg : LibC::Long, parg : Void*) : LibC::Long
 
   fun evp_pkey_new = EVP_PKEY_new : EvpPKey*
-  fun evp_pkey_id = EVP_PKEY_id(pkey : EvpPKey*) : LibC::Int
   fun evp_pkey_free = EVP_PKEY_free(pkey : EvpPKey*)
-  fun evp_pkey_size = EVP_PKEY_size(pkey : EvpPKey*) : LibC::Int
-  fun evp_pkey_bits = EVP_PKEY_bits(pkey : EvpPKey*) : LibC::Int
+  {% if compare_versions(LibCrypto::OPENSSL_VERSION, "3.0.0") >= 0 %}
+    fun evp_pkey_id = EVP_PKEY_get_id(pkey : EvpPKey*) : LibC::Int
+    fun evp_pkey_base_id = EVP_PKEY_get_base_id(pkey : EvpPKey*) : LibC::Int
+    fun evp_pkey_size = EVP_PKEY_get_size(pkey : EvpPKey*) : LibC::Int
+    fun evp_pkey_bits = EVP_PKEY_get_bits(pkey : EvpPKey*) : LibC::Int
+    fun evp_pkey_security_bits = EVP_PKEY_get_security_bits(pkey : EvpPKey*) : LibC::Int
+  {% else %}
+    fun evp_pkey_id = EVP_PKEY_id(pkey : EvpPKey*) : LibC::Int
+    fun evp_pkey_base_id = EVP_PKEY_base_id(pkey : EvpPKey*) : LibC::Int
+    fun evp_pkey_size = EVP_PKEY_size(pkey : EvpPKey*) : LibC::Int
+    fun evp_pkey_bits = EVP_PKEY_bits(pkey : EvpPKey*) : LibC::Int
+    fun evp_pkey_security_bits = EVP_PKEY_security_bits(pkey : EvpPKey*) : LibC::Int
+  {% end %}
+
   fun evp_pkey_get0 = EVP_PKEY_get0(pkey : EvpPKey*) : Void*
   fun evp_pkey_get0_rsa = EVP_PKEY_get0_RSA(pkey : EvpPKey*) : Rsa*
   fun evp_pkey_get0_dsa = EVP_PKEY_get0_DSA(pkey : EvpPKey*) : Dsa*


### PR DESCRIPTION
Fixes #9

Looking at the docs between 
https://www.openssl.org/docs/man1.1.1/man3/EVP_PKEY_size.html
and
https://www.openssl.org/docs/man3.0/man3/EVP_PKEY_size.html

it looks like renamed a lot of functions from `_whatever` to  `_get_whatever`, then added some aliases for backwards compatibility. 

It builds and specs pass locally, but I do see this:

```
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (128)
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (128)
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (128)
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (133)
WARNING: Unsupported BIO ctrl call (128)
```

Crystal 1.5 should fix that warning https://github.com/crystal-lang/crystal/pull/12034